### PR TITLE
Fix path to createlinks.cmd

### DIFF
--- a/install_components.cmd
+++ b/install_components.cmd
@@ -40,4 +40,4 @@ rem del auto-install.js msys2-x86_64-latest.tar* Win64OpenSSL-1_1_1g.exe nsis-3.
 rd /s /q nsprocess
 rd /s /q nsprocess
 
-call createlinks.cmd
+call lib/createlinks.cmd


### PR DESCRIPTION
Fixes this:

    C:\Users\CX\Downloads\deluge2-win-build-master>call createlinks.cmd
    'createlinks.cmd' is not recognized as an internal or external command,
    operable program or batch file.